### PR TITLE
Actualizado Vagrantfile e instruções (no README.md)

### DIFF
--- a/ProjectSubmit/Vagrantfile
+++ b/ProjectSubmit/Vagrantfile
@@ -1,69 +1,32 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
+
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
 
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "jadesystems/rails5"
+  config.vm.box_version = "0.5.0"
+  config.vm.box_check_update = true
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+  config.vm.provider "virtualbox" do |v|
+    v.linked_clone = true
+  end
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # Queremos a VM acessível na rede? Com que IP?
+  # Descomentar e fazer vagrant reload
+  # config.vm.network "public_network", ip: "192.168.10.50"
+
+  # Precisamos de mais portas host <-> guest?
   # config.vm.network "forwarded_port", guest: 80, host: 8080
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
+  # É necessário alterar hw da VM?
   # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  #   vb.memory = "2048"
+  #   vb.cpus = 1
   # end
 
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
+  # Queremos correr alguma configuração extra no fim?
+  # (coisas mais complexas com pupper, ansible, chef)
   # config.vm.provision "shell", inline: <<-SHELL
   #   apt-get update
   #   apt-get install -y apache2

--- a/ProjectSubmit/config/environments/development.rb
+++ b/ProjectSubmit/config/environments/development.rb
@@ -51,4 +51,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/README.md
+++ b/README.md
@@ -5,6 +5,75 @@
 
 <img src="http://portal2.ipt.pt/img/logo.png" alt="Smiley face" height="40%" width="70%">
 
-Teste Pedro na minha arvore
+## Vagrant: Como utilizar?
 
+### Instalar software:
+* [Vagrant](https://www.vagrantup.com/downloads.html)
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [Git BASH](https://git-scm.com/download/win) - apenas para Windows
+ * Porquê? Para ter um cliente SSH (e restantes tools) que permita fazer *vagrant ssh*
+* Reiniciar
+
+Em **Windows** o caminho para a pasta dos plugins do Vagrant não pode ter espaços. Por isso:
+* Criar uma pasta algures (ex: D:/Dev/HashiCorp/VagrantHome)
+* Definir uma variável de ambiente VAGRANT_HOME com esse valor.
+Para fazer isto na linha de comandos:
+```
+setx VAGRANT_HOME D:/Dev/HashiCorp/VagrantHome
+```
  
+Instalar plugin vagrant-vbguest, na linha de comandos:
+```
+vagrant plugin install vagrant-vbguest
+```
+
+
+### Iniciar a VM de desenvolvimento (1a vez):
+
+#### TL;DR
+```
+# na pasta do projecto com (Git) BASH:
+vagrant up
+vagrant reload
+vagrant ssh
+cd /vagrant
+bundle install
+rails db:setup
+rails server -b0.0.0.0
+```
+
+#### Versão detalhada:
+Ter versão actualizada do projecto, onde já exista um Vagrantfile (caso contrário fazer pull). Abrir uma consola na pasta do projecto - se estiverem em Windows, o ideal é abrir a **Git BASH** (botão direito na pasta... "Git BASH Here"). Iniciar a VM.
+```
+vagrant up
+```
+
+
+A primeira execução demora pois vai importar (net) e descompactar a VM.
+
+É provável que depois o *provisioning* falhe, causado por um lock ("Could not get lock /var/lib/dpkg/lock"). A solução mais fácil é voltar a carregar as configurações:
+
+```
+vagrant reload
+```
+
+
+Se continuar a dar o mesmo erro terão que entrar na VM, apagar o ficheiro e repetir (vagrant ssh, sudo rm /var/lib/dpkg/lock, logout, vagrant reload).
+
+
+### Utilização:
+Depois de configurada, podem fazer `vagrant up`, `vagrant suspend`, `vagrant status` e `vagrant destroy` para iniciar, terminar, ver o estado e destruir uma VM.
+
+Tudo o que faziam na linha de comandos (`rails ...`, `bundle ...`, etc) é feito da mesma forma, dentro da VM. Dentro da vm a pasta "/vagrant" está ligada à vossa pasta do projecto local.
+
+Portanto, na pasta do projecto:
+```
+vagrant ssh
+cd /vagrant
+bundle install
+rails db:setup
+rails server -b0.0.0.0
+```
+Para entrar na VM por ssh, ir para a pasta /vagrant, instalar as gems necessárias, iniciar a BD e iniciar o servidor. A app deve estar acessível em http://localhost:3000/
+
+Toda a edição (commits, etc.) é feita na vossa máquina, tal como antes.


### PR DESCRIPTION
Vagrantfile com VM mais recente e versão definida para garantir que todos vão usar a mesma versão.
Escrevi algumas instruções para quem não sabe usar - ver readme do repositório.

@nelsonmpg e @PedroMatos1972 , isto vai fazer com que vocês também saquem uma nova VM e por isso tenham que voltar a fazer 2 ou 3 comandos (up e reload).